### PR TITLE
Replaced Colors.js with Chalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Note: To combine colors, bgColors and style, set them as an array like this:
 	
 
 Or chain Chalk functions like this:
+
 	...
 		stamp: require("chalk").red.bgYellow.underline;
 	... 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,27 @@ From version 2.0 the second parameter is an object with several options. As a ba
 
 * **options.metadata** {String/Object/Function}<br>Types can be String, Object (interpreted with util.inspect), or Function. See the test-metadata.js for examples.<br>**Note** that metadata can still be sent as the third parameter (as in vesion 1.6) as a backward compatibillity feature, but this is deprecated. <br>**Default**: undefined
  
-* **options.colors** {Object}<br>An object representing a color theme. More info [here](https://www.npmjs.com/package/colors).
+* **options.colors** {Object}<br>An object representing a color theme. More info [here](https://www.npmjs.com/package/chalk).
 
-    * **options.colors.stamp** {String/Array} <br>**Default:** []
+    * **options.colors.stamp** {String/Array<String>/Function} <br>**Default:** []
 
-    * **options.colors.label** {String/Array} <br>**Default:** []
+    * **options.colors.label** {String/Array<String>/Function} <br>**Default:** []
 
-    * **options.colors.metadata** {String/Array} <br>**Default:** []
+    * **options.colors.metadata** {String/Array<String>/Function} <br>**Default:** []
 
 Note: To combine colors, bgColors and style, set them as an array like this:
 
 	...
 		stamp: ["black", "bgYellow", "underline"]
 	... 
+	
+
+Or chain Chalk functions like this:
+	...
+		stamp: require("chalk").red.bgYellow.underline;
+	... 
+	
+
 Note also that by sending the parameter `--no-color` when you start your node app, will prevent any colors from console.
 
 	$ node my-app.js --no-color

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@
 
 var dateFormat = require( "dateformat" );
 var merge = require( "merge" );
-var colors = require( "colors" );
+var chalk = require( "chalk" );
 var defaults = require( "./defaults.json" );
 var util = require( 'util' );
 
@@ -36,9 +36,48 @@ module.exports = function ( con, options, prefix_metadata ) {
         return !~options.exclude.indexOf( m );
     } );
 
-    // Set the color theme
-    colors.setTheme( options.colors );
-
+    //SET COLOR THEME START
+    var noColor = function(str){ return str; }; //Default behaviour (no color)
+    
+    var getColor = function(origColor)
+    {
+        //If color is a chalk function already, just return it
+        if(typeof origColor === 'function')
+        {
+            return origColor;
+        }
+        //If color is an string, check if a function in chalk exists
+        if(typeof origColor === 'string')
+        {
+            return chalk[""+origColor] ? chalk[""+origColor] : noColor;
+        }
+        //If color is an array, check the contents for color strings
+        if(Array.isArray(origColor))
+        {
+            if(origColor.length > 0)
+            {
+                var color = chalk;
+                for (var i = 0; i < origColor.length; i++) {
+                    if(typeof origColor[i] === 'string')
+                    {
+                        color = color[""+origColor[i]];
+                    }
+                }
+                return color;
+            }
+            else{
+                return noColor;
+            }
+        }
+        return noColor;
+    }
+    
+    var colorTheme = {};
+    colorTheme.stamp = getColor(options.colors.stamp);
+    colorTheme.label = getColor(options.colors.label);
+    colorTheme.metadata = getColor(options.colors.metadata);
+    //SET COLOR THEME END
+    
     var original_functions = [];
 
     var slice = Array.prototype.slice;
@@ -51,12 +90,12 @@ module.exports = function ( con, options, prefix_metadata ) {
 
         con[f] = function () {
 
-            var prefix = ("[" + dateFormat( pattern ) + "]").stamp + " ";
+            var prefix = colorTheme.stamp("[" + dateFormat( pattern ) + "]")+" ";
             var args = slice.call( arguments );
 
             // Add label if flag is set
             if ( options.label ) {
-                prefix += ("[" + f.toUpperCase() + "]").label + "      ".substr( f.length );
+                prefix += colorTheme.label("[" + f.toUpperCase() + "]")+"      ".substr( f.length );
             }
 
             // Add metadata if any
@@ -70,7 +109,7 @@ module.exports = function ( con, options, prefix_metadata ) {
             }
 
             if ( metadata ) {
-                prefix += metadata.metadata + " ";
+                prefix += colorTheme.metadata(metadata) + " "; //Metadata
             }
 
             if ( f === "error" || f === "warn" || ( f === "assert" && !args[0] ) ) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         {
             "name": "Christiaan Westerbeek",
             "url": "https://github.com/devotis"
+        },
+        {
+            "name": "Leon Lucardie",
+            "url": "https://github.com/Gameleon12"
         }
     ],
     "description": "Patch NodeJS console methods in order to add timestamp information by pattern",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "dateformat": "^1.0.11",
         "merge": "^1.2.0",
-        "colors": "^1.1.2"
+        "chalk": "^1.1.1"
     },
     "devDependencies": {
         "filesize": "^3.1.2"


### PR DESCRIPTION
Replaced the Colors.js dependancy to Chalk.
Colors.js caused some major conflicts in existing projects by adding to/changing the
String.prototype. Chalk doesn't have this issue.

Chalk has support for all the colors and styles that Colors.js supports, with the exception of the `rainbow`, `zebra`, `america`,`trap` and `random` styles.

Since Chalk uses (chained) functions instead of strings to identify colors a getColor function has been added that will lookup (and chain) chalk functions by string or string array for backwards compatibility.