### PR TITLE
Switched typings to NodeJS.WriteStream to remove DOM library requirement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,8 +13,8 @@ declare function consoleStamp(console: Console, options?: {
     include?: string[]
     level?: string
     extend?: Record<string, number>
-    stdout?: WritableStream
-    stderr?: WritableStream
+    stdout?: NodeJS.WriteStream
+    stderr?: NodeJS.WriteStream
     use_custom_message?: boolean
 }): void;
 


### PR DESCRIPTION
WritableStream being a web api not present in node, typescript will display an error unless the DOM library is included.
NodeJS.WriteStream is the type of process.stdout. I assume this would not cause type issues for anyone else, unless the package is being used on browsers.