### PR TITLE
Add type for datetime format to allow autocompletion

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { DateFormatMasks } from "dateformat";
+
 export type Token = ( payload: TokenPayload ) => string | number;
 
 export interface TokenPayload {
@@ -23,7 +25,7 @@ declare global {
 }
 
 declare function consoleStamp(console: Console, options?: {
-    format?: string
+    format?: `:date(${keyof DateFormatMasks})`
     tokens?: Record<string, Token>
     include?: string[]
     level?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
+        "@types/dateformat": "^5.0.2",
         "chalk": "^4.1.2",
         "dateformat": "^4.6.3"
       },
@@ -1302,6 +1303,11 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/dateformat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.2.tgz",
+      "integrity": "sha512-M95hNBMa/hnwErH+a+VOD/sYgTmo15OTYTM2Hr52/e0OdOuY+Crag+kd3/ioZrhg0WGbl9Sm3hR7UU+MH6rfOw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
@@ -5147,6 +5153,11 @@
       "requires": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "@types/dateformat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.2.tgz",
+      "integrity": "sha512-M95hNBMa/hnwErH+a+VOD/sYgTmo15OTYTM2Hr52/e0OdOuY+Crag+kd3/ioZrhg0WGbl9Sm3hR7UU+MH6rfOw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/dateformat": "^5.0.2",
     "chalk": "^4.1.2",
     "dateformat": "^4.6.3"
   },


### PR DESCRIPTION
Hey. Thanks for this package, it's very useful. I've noticed that the `format` option simply uses `string` as type and has no autocompletion. So I think this can be improved by adding the `@types/dateformat` package and then constructing the type based on that. Works nicely:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/f3bc845f-7457-4795-888e-8d21e22218f3" />

I've consciously added `@types/dateformat` to the dependencies and not devDependencies, I think this should be right if the `d.ts` file of this package relies on it (so it's part of the API of this package).